### PR TITLE
Section4: API 개발 고급 - 지연 로딩과 조회 성능의 최적화

### DIFF
--- a/jpashop/build.gradle
+++ b/jpashop/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-devtools'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate5'
+
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
     implementation 'junit:junit:4.13.1'
     compileOnly 'org.projectlombok:lombok'

--- a/jpashop/src/main/java/jpabook/jpashop/InitDb.java
+++ b/jpashop/src/main/java/jpabook/jpashop/InitDb.java
@@ -1,0 +1,84 @@
+package jpabook.jpashop;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jpabook.jpashop.domain.*;
+import jpabook.jpashop.domain.item.Book;
+import jpabook.jpashop.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class InitDb {
+
+    private final InitService initService;
+
+    @PostConstruct
+    public void init(){
+        initService.dbInit1();
+    }
+
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService{
+        private final EntityManager em;
+        public void dbInit1(){
+            Member member = createMember("userA", "서울", "1", "1111");
+            em.persist(member);
+
+            Book book1 = createBook("JPA1 Book", 10000, 100);
+            em.persist(book1);
+
+            Book book2 = createBook("JPA2 Book", 20000, 100);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 10000, 1);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 20000, 2);
+
+            Delivery delivery = createDelivery(member);
+            Order.createOrder(member, delivery, orderItem1, orderItem2);
+        }
+
+        private static Delivery createDelivery(Member member) {
+            Delivery delivery = new Delivery();
+            delivery.setAddress(member.getAddress());
+            return delivery;
+        }
+
+        public void dbInit2(){
+            Member member = createMember("userB", "진주", "2", "2222");
+            em.persist(member);
+
+            Book book1 = createBook("JPA1 Book", 20000, 200);
+            em.persist(book1);
+
+            Book book2 = createBook("JPA2 Book", 40000, 300);
+            em.persist(book2);
+
+            OrderItem orderItem1 = OrderItem.createOrderItem(book1, 20000, 3);
+            OrderItem orderItem2 = OrderItem.createOrderItem(book2, 40000, 4);
+
+            Delivery delivery = createDelivery(member);
+            Order order = Order.createOrder(member, delivery, orderItem1, orderItem2);
+            em.persist(order);
+        }
+
+        private static Book createBook(String name, int price, int stockQuantity) {
+            Book book1 = new Book();
+            book1.setName(name);
+            book1.setPrice(price);
+            book1.setStockQuantity(stockQuantity);
+            return book1;
+        }
+
+        private static Member createMember(String name, String city, String s, String z) {
+            Member member = new Member();
+            member.setName(name);
+            member.setAddress(new Address(city, s, z));
+            return member;
+        }
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -1,7 +1,9 @@
 package jpabook.jpashop;
 
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
@@ -9,6 +11,15 @@ public class JpashopApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(JpashopApplication.class, args);
+    }
+
+    // 지연 로딩을 강제로 불러옴.
+    @Bean
+    Hibernate5Module hibernate5Module() {
+        Hibernate5Module hibernate5Module = new Hibernate5Module();
+//        hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, true);
+
+        return hibernate5Module;
     }
 
 }

--- a/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
+++ b/jpashop/src/main/java/jpabook/jpashop/JpashopApplication.java
@@ -14,12 +14,12 @@ public class JpashopApplication {
     }
 
     // 지연 로딩을 강제로 불러옴.
-    @Bean
-    Hibernate5Module hibernate5Module() {
-        Hibernate5Module hibernate5Module = new Hibernate5Module();
+//    @Bean
+//    Hibernate5Module hibernate5Module() {
+//        Hibernate5Module hibernate5Module = new Hibernate5Module();
 //        hibernate5Module.configure(Hibernate5Module.Feature.FORCE_LAZY_LOADING, true);
-
-        return hibernate5Module;
-    }
+//
+//        return hibernate5Module;
+//    }
 
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,13 +1,17 @@
 package jpabook.jpashop.api;
 
+import jpabook.jpashop.domain.Address;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.domain.Orderstatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
 import jpabook.jpashop.service.OrderService;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /*
@@ -31,5 +35,30 @@ public class OrderSimpleApiController {
         return all;
     }
 
+    @GetMapping("/api/v2/simple-orders")
+    public List<SimpleOrderDto> orderV2(){
+        List<Order> orders = orderRepository.findAllByString(new OrderSearch());
+
+        return orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .toList();
+    }
+
+    @Data
+    static class SimpleOrderDto {
+        private Long orderId;
+        private String name;
+        private LocalDateTime orderDate;
+        private Orderstatus orderStatus;
+        private Address address;
+
+        public SimpleOrderDto(Order order) {
+            this.orderId = order.getId();
+            this.name = order.getMember().getName();
+            this.orderDate = order.getOrderDate();
+            this.orderStatus = order.getStatus();
+            this.address = order.getDelivery().getAddress();
+        }
+    }
 
 }

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -44,6 +44,16 @@ public class OrderSimpleApiController {
                 .toList();
     }
 
+    @GetMapping("/api/v3/simple-orders")
+    public List<SimpleOrderDto> orderV3(){
+        List<Order> orders = orderRepository.findAllWithMemberDelivery();
+        List<SimpleOrderDto> result = orders.stream()
+                .map(o -> new SimpleOrderDto(o))
+                .toList();
+
+        return result;
+    }
+
     @Data
     static class SimpleOrderDto {
         private Long orderId;

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -5,7 +5,8 @@ import jpabook.jpashop.domain.Order;
 import jpabook.jpashop.domain.Orderstatus;
 import jpabook.jpashop.repository.OrderRepository;
 import jpabook.jpashop.repository.OrderSearch;
-import jpabook.jpashop.service.OrderService;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryRepository;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +25,7 @@ Order -> Delivery
 public class OrderSimpleApiController {
 
     private final OrderRepository orderRepository;
+    private final OrderSimpleQueryRepository orderSimpleQueryRepository;
 
     @GetMapping("/api/v1/simple-orders")
     public List<Order> ordersV1(){
@@ -52,6 +54,11 @@ public class OrderSimpleApiController {
                 .toList();
 
         return result;
+    }
+
+    @GetMapping("/api/v4/simple-orders")
+    public List<OrderSimpleQueryDto> orderV4(){
+        return orderSimpleQueryRepository.findOrderDtos();
     }
 
     @Data

--- a/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/api/OrderSimpleApiController.java
@@ -1,0 +1,35 @@
+package jpabook.jpashop.api;
+
+import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.repository.OrderRepository;
+import jpabook.jpashop.repository.OrderSearch;
+import jpabook.jpashop.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/*
+Order
+Order -> Member
+Order -> Delivery
+ */
+@RestController
+@RequiredArgsConstructor
+public class OrderSimpleApiController {
+
+    private final OrderRepository orderRepository;
+
+    @GetMapping("/api/v1/simple-orders")
+    public List<Order> ordersV1(){
+        List<Order> all = orderRepository.findAllByString(new OrderSearch());
+        for(Order order : all){
+            order.getMember().getName(); // Lazy 강제 초기화
+            order.getDelivery().getAddress(); // Lazy 강제 초기화
+        }
+        return all;
+    }
+
+
+}

--- a/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/Member.java
@@ -26,6 +26,7 @@ public class Member {
     @Embedded
     private Address address;
 
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY)
     private List<Order> orders = new ArrayList<>(); // best!
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/OrderItem.java
@@ -1,5 +1,6 @@
 package jpabook.jpashop.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jpabook.jpashop.domain.item.Item;
 import lombok.AccessLevel;
@@ -21,6 +22,7 @@ public class OrderItem {
     @JoinColumn(name = "item_id")
     private Item item;
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "order_id")
     private Order order;

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.*;
 import jpabook.jpashop.domain.Order;
+import jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;

--- a/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/OrderRepository.java
@@ -86,6 +86,12 @@ public class OrderRepository {
         return query.getResultList();
     }
 
-
-
+    // fetch join
+    public List<Order> findAllWithMemberDelivery() {
+        return em.createQuery(
+                "select o from Order o" +
+                        " join fetch o.member m" +
+                        " join fetch o.delivery d", Order.class
+        ).getResultList();
+    }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryDto.java
@@ -1,0 +1,25 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jpabook.jpashop.domain.Address;
+import jpabook.jpashop.domain.Orderstatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class OrderSimpleQueryDto {
+
+    private Long orderId;
+    private String name;
+    private LocalDateTime orderDate;
+    private Orderstatus orderStatus;
+    private Address address;
+
+    public OrderSimpleQueryDto(Long orderId, String name, LocalDateTime orderDate, Orderstatus orderStatus, Address address) {
+        this.orderId = orderId;
+        this.name = name;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.address = address;
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/order/simplequery/OrderSimpleQueryRepository.java
@@ -1,0 +1,22 @@
+package jpabook.jpashop.repository.order.simplequery;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderSimpleQueryRepository {
+
+    private final EntityManager em;
+
+    public List<OrderSimpleQueryDto> findOrderDtos(){
+        return em.createQuery("select new jpabook.jpashop.repository.order.simplequery.OrderSimpleQueryDto(o.id, m.name, o.orderDate, o.status, d.address) " +
+                        "from Order o" +
+                        " join o.member m" +
+                        " join o.delivery d", OrderSimpleQueryDto.class)
+                .getResultList();
+    }
+}

--- a/jpashop/src/main/resources/application.yml
+++ b/jpashop/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
 #        show_sql: true


### PR DESCRIPTION
- 엔티티를 직접 노출하는 것은 비권장!!
 -> API 스펙의 변경, 보안 취약, 유지보수의 어려움 때문
- 반환하려면 엔티티를 DTO로 변환하거나, JPA에서 DTO로 바로 조회를 하는 방법을 사용하자!